### PR TITLE
注文履歴画面、カート遷移画面、会員情報編集の修正

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -13,14 +13,18 @@ class Admin::CustomersController < ApplicationController
   end
 
   def update
-    customer = Customer.find(params[:id])
-    customer.update(customer_params)
-    redirect_to admin_customers_path(customers)
+    @customer = Customer.find(params[:id])
+    if @customer.update(customer_params)
+      flash[:notice] = "会員情報を更新しました。"
+      redirect_to admin_customer_path(@customer.id)
+    else
+      render :edit
+    end
   end
 
   private
 
   def customer_params
-    params.require(:customer).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :address, :postal_code, :telephone_number, :is_deleted)
+    params.require(:customer).permit(:last_name, :first_name, :last_name_kana, :first_name_kana, :email, :address, :postal_code, :phone_number, :is_active, :is_deleted)
   end
 end

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,4 +1,6 @@
 class CartItemsController < ApplicationController
+  before_action :check_login, only: [:create]
+
   def index
     @cart_item = CartItem.all
   end
@@ -13,8 +15,8 @@ class CartItemsController < ApplicationController
       cart_item.update(amount: cart_item.amount)
       redirect_to cart_items_path
     else
-      cart_item.save
-      redirect_to cart_items_path
+
+      redirect_to new_customer_session_path
     end
   end
 
@@ -40,5 +42,10 @@ class CartItemsController < ApplicationController
     params.require(:cart_item).permit(:item_id, :amount)
   end
 
+  def check_login
+    unless current_customer
+      redirect_to new_customer_session_path
+    end
+  end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -27,13 +27,16 @@ class OrdersController < ApplicationController
   end
 
   def index
+    @order = Order.all
   end
 
   def show
+    @order = Order.find(params[:id])
   end
 
   private
 
   def order_params
     params.require(:order).permit(:payment_method, :postal_code, :address, :name, :amount, :customer_id, :shipping_cost, :order_status)
+  end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -13,7 +13,7 @@ class Customer < ApplicationRecord
   end
   
   def customer_status
-    if is_deleted == false
+    if is_active
       "有効"
     else
       "退会"
@@ -21,7 +21,7 @@ class Customer < ApplicationRecord
   end
 
   def active_for_authentication?
-    super && (is_deleted == false)
+    super && is_active
   end
 
   has_many :cart_items

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -5,4 +5,5 @@ class Order < ApplicationRecord
 
   enum payment_method: {credit_card: 0, transfer: 1}
   enum order_status: {wait_payment: 0, confirm_payment: 1, making: 2, preparing_ship: 3, finish_prepare: 4}
+
 end

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -2,54 +2,55 @@
   <div class="row">
     <div class="col">
       <h4 class="my-5"><%= @customer.full_name %>さんの会員情報編集</h4>
-      <table class="table table-borderless">
 
-        <%= form_with(model: [:admin, @customer], remote: true) do |f| %>
-        <tr>
-          <td>会員ID</td>
-          <td><%= @customer.id %></td>
-        </tr>
-        <tr>
-          <td>氏名</td>
-          <td><%= f.text_field :last_name %> <%= f.text_field :first_name %></td>
-        </tr>
-        <tr>
-          <td>フリガナ</td>
-          <td><%= f.text_field :last_name_kana %> <%=f.text_field :first_name_kana %></td>
-        </tr>
-        <tr>
-          <td>郵便番号</td>
-          <td><%= f.text_field :postal_code %></td>
-        </tr>
-        <tr>
-          <td>住所</td>
-          <td><%= f.text_field :address %></td>
-        </tr>
-        <tr>
-          <td>電話番号</td>
-          <td><%= f.text_field :phone_number %></td>
-        </tr>
-        <tr>
-          <td>メールアドレス</td>
-          <td><%= f.text_field :email %></td>
-        </tr>
-        <tr>
-          <td>会員ステータス</td>
-          <td>
-            <%= f.radio_button :is_active, :true %>
-            <%= f.label :is_active, "有効", { value: :true } %>
-            
-            <%= f.radio_button :is_active, :false %>
-            <%= f.label :is_active, "退会", { value: :false } %>
-          </td>
-        <tr>
+      <%= form_with(model: [:admin, @customer], remote: true) do |f| %>
+        <table class="table table-borderless">
+          <tr>
+            <td>会員ID</td>
+            <td><%= @customer.id %></td>
+          </tr>
+          <tr>
+            <td>氏名</td>
+            <td><%= f.text_field :last_name %> <%= f.text_field :first_name %></td>
+          </tr>
+          <tr>
+            <td>フリガナ</td>
+            <td><%= f.text_field :last_name_kana %> <%=f.text_field :first_name_kana %></td>
+          </tr>
+          <tr>
+            <td>郵便番号</td>
+            <td><%= f.text_field :postal_code %></td>
+          </tr>
+          <tr>
+            <td>住所</td>
+            <td><%= f.text_field :address %></td>
+          </tr>
+          <tr>
+            <td>電話番号</td>
+            <td><%= f.text_field :phone_number %></td>
+          </tr>
+          <tr>
+            <td>メールアドレス</td>
+            <td><%= f.text_field :email %></td>
+          </tr>
+          <tr>
+            <td>会員ステータス</td>
+            <td>
+              <%= f.radio_button :is_active, :true %>
+              <%= f.label :is_active, "有効", { value: :true } %>
+              
+              <%= f.radio_button :is_active, :false %>
+              <%= f.label :is_active, "退会", { value: :false } %>
+            </td>
+          <tr>
 
-        <tr>
-          <td><%= f.submit "変更を保存", class:"btn btn-success" %></td>
-        </tr>
-        <% end %>
-      
-      </table>
+          <tr>
+            <td></td>
+            <td><%= f.submit "変更を保存", class:"btn btn-success" %></td>
+          </tr>
+
+        </table>
+      <% end %>
     </div>
   </div>
 </div>

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -15,7 +15,7 @@
         </tr>
         <tr>
           <td>フリガナ</td>
-          <td><%= f.text_field :last_name_kana %> <f.text_field :first_name_kana %></td>
+          <td><%= f.text_field :last_name_kana %> <%=f.text_field :first_name_kana %></td>
         </tr>
         <tr>
           <td>郵便番号</td>
@@ -37,16 +37,16 @@
           <td>会員ステータス</td>
           <td>
             <%= f.radio_button :is_active, :true %>
-            <%= f.label :in_active, "有効", { value: :true } %>
+            <%= f.label :is_active, "有効", { value: :true } %>
             
             <%= f.radio_button :is_active, :false %>
-            <%= f.label :in_active, "退会", { value: :false } %>
+            <%= f.label :is_active, "退会", { value: :false } %>
           </td>
         <tr>
 
         <tr>
           <td></td>
-          <td><%= f.submit "変更を保存", class:"btn btn-success" %></td>
+          <td><%= f.submit "変更を保存", class:"btn btn-success", data: {"turbolinks" => false} %></td>
         </tr>
         <% end %>
       

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -4,7 +4,7 @@
       <h4 class="my-5"><%= @customer.full_name %>さんの会員情報編集</h4>
       <table class="table table-borderless">
 
-        <%= form_with model: [:admin, @customer] do |f| %>
+        <%= form_with(model: [:admin, @customer], remote: true) do |f| %>
         <tr>
           <td>会員ID</td>
           <td><%= @customer.id %></td>
@@ -45,8 +45,7 @@
         <tr>
 
         <tr>
-          <td></td>
-          <td><%= f.submit "変更を保存", class:"btn btn-success", data: {"turbolinks" => false} %></td>
+          <td><%= f.submit "変更を保存", class:"btn btn-success" %></td>
         </tr>
         <% end %>
       

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,4 +1,7 @@
 <div class="container">
+  <div>
+  <%= flash[:notice] %>
+  </div>
   <div class="row">
     <div class="col">
       <h4 class="my-5"><%= @customer.full_name %>さんの会員詳細</h4>

--- a/app/views/cart_items/index.html.erb
+++ b/app/views/cart_items/index.html.erb
@@ -20,9 +20,9 @@
    <tr>
       <td>
          <% if cart_item.item.item_image.attached? %>
-            <%= image_tag cart_item.item_image, size: "80x50" %>
+            <%= image_tag cart_item.item.item_image, size: "80x50" %>
          <% else %>
-            <%= image_tag 'noimage', size: "80x50" %>
+            <%= image_tag 'noimage.png', size: "80x50" %>
          <% end %>
          <%= cart_item.item.name %>
       </td>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,2 +1,23 @@
-<h1>Orders#index</h1>
-<p>Find me in app/views/orders/index.html.erb</p>
+<table class="table table-bordered mx-auto" style="max-width: 1300px;">
+   <div class="row mx-auto" style="max-width: 1000px;">
+      <span class="bg-light" style="font-size: 1.5rem;">注文詳細一覧</span>
+   </div>
+   <tr class="table-active">
+      <th>注文日</th>
+      <th>配送先</th>
+      <th>注文商品</th>
+      <th>支払金額</th>
+      <th>ステータス</th>
+      <th>注文詳細</th>
+   </tr>
+   <% @order.each do |order| %>
+      <tr>
+         <td><%= order.created_at %></td>
+         <td><%= order.address %></td>
+         <td><%= order.item.name %></td>
+         <td>金額</td>
+         <td><%= order.status %></td>
+         <td><%= link_to "表示する", order_path, class: "btn btn-primary" %></td>
+      </tr>
+   <% end %>
+</table>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,2 +1,1 @@
-<h1>Orders#show</h1>
-<p>Find me in app/views/orders/show.html.erb</p>
+<h4 class="bg-light">注文履歴詳細</h4>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,1 +1,67 @@
-<h4 class="bg-light">注文履歴詳細</h4>
+<div class="container">
+  <h4 class="bg-light">注文履歴詳細</h4>
+  <div class="row">
+    <div class="col">
+      注文情報
+      <table class="table">
+        <tr>
+          <td>注文日</td>
+          <td><%= @order.created_at %></td>
+        </tr>
+        <tr>
+          <td>配送先</td>
+          <td><%= @order.address %></td>
+        </tr>
+        <tr>
+          <td>支払方法</td>
+          <td>支払方法</td>
+        </tr>
+        <tr>
+          <td>ステータス</td>
+          <td><%= order.status %></td>
+        </tr>
+      </table>
+    </div>
+
+    <div class="col">
+      請求情報
+      <table class="table">
+        <tr>
+          <td>商品合計</td>
+          <td><商品合計/td>
+        </tr>
+        <tr>
+          <td>配送料</td>
+          <td>配送料</td>
+        </tr>
+        <tr>
+          <td>ご請求額</td>
+          <td>商品合計＋配送料</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+
+  <div class="row">
+    <div>
+      注文内容
+      <table class="table">
+      <tr>
+        <th>商品</th>
+        <th>単価(税込)</th>
+        <th>個数</th>
+        <th>小計</th>
+      </tr>
+      <% @order.each do |order| %>←書き換える
+        <tr>
+           <td><%= order.item.name %></td>
+           <td>金額</td>
+           <td><%= order.order_detail.amount %></td>
+           <td><%= order.status %></td>
+           <td>小計(単価x個数)</td>
+        </tr>
+      <% end %>
+      </table>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- 注文履歴一覧画面を作成しました。
- 注文履歴詳細画面を作成しました。
- 非ログイン時にカートに入れるを押すと、ログイン画面に遷移するように設定しました。
- 管理者側の会員情報の編集ができるように修正しました。